### PR TITLE
Add fingerprint and location.lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ docs/_build
 *.sqlite
 .tox
 .env
+.eggs/
 
 .coverage
 htmlcov/


### PR DESCRIPTION
First of all thanks for this package! I wanted to use it in combination with Gitlab since they have a code quality widget which support code climate files. However Gitlab requires extra fields to be available (fingerprint and location.lines)

See https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html

You can then run it via `flake8 --format=codeclimate --exit-zero  src/ tests/ | jq -s . > py-codeclimate.json` in a .gitlab-ci.yml file

